### PR TITLE
fix: use _peerConnectionId for accurate volume tracking

### DIFF
--- a/src/hooks/useTrackVolume.ts
+++ b/src/hooks/useTrackVolume.ts
@@ -29,7 +29,7 @@ export function useTrackVolume(
 
   const mediaStreamTrack = track?.mediaStreamTrack;
   const hasMediaStreamTrack = mediaStreamTrack != null;
-  const peerConnectionId = mediaStreamTrack.peerConnectionId ?? -1;
+  const peerConnectionId = mediaStreamTrack._peerConnectionId ?? -1;
   const mediaStreamTrackId = mediaStreamTrack.id;
 
   let [volume, setVolume] = useState(0.0);


### PR DESCRIPTION
The current implementation uses mediaStreamTrack.peerConnectionId, which is undefined in certain platforms. This PR fixes the issue by accessing the internal _peerConnectionId property. Though private, this is necessary for consistent behavior and avoids a silent failure in the volume processor. Tested and verified to resolve the issue.
Issue I faced From:
https://livekit-users.slack.com/archives/C07FVFGAUKX/p1743737909092499